### PR TITLE
Request Attachments, other fixes

### DIFF
--- a/examples/src/main/scala/Examples.scala
+++ b/examples/src/main/scala/Examples.scala
@@ -50,11 +50,11 @@ object Main extends App {
   class MyHandler {
     var num = 0
 
-    def incrementBy(i: Int): Unit = {
+    def incrementBy(i: Int): Int = {
       num += i
+      num
     }
 
-    def get = num
   }
   implicit val MyHandlerProvider = new AttachmentProvider[MyHandler] {
     def provide(ctx: scalene.RequestHandlerContext) = new MyHandler
@@ -74,7 +74,11 @@ object Main extends App {
       "bye".ok
     },
 
-    GET / "increment" + Attachment[MyHandler] to {h => h.incrementBy(1); h.get.ok}
+    (GET / "increment" / optional(![Int])) + Attachment[MyHandler] to {
+      case (Some(i), h) => h.incrementBy(i).ok
+      case (None, h) => h.incrementBy(1).ok
+    }
+
   )
   
   val settings = Settings.basic(serverName = "examples", port = 8080)

--- a/examples/src/main/scala/Examples.scala
+++ b/examples/src/main/scala/Examples.scala
@@ -46,6 +46,19 @@ object Main extends App {
       }
     }.map{_.ok}
   }
+
+  class MyHandler {
+    var num = 0
+
+    def incrementBy(i: Int): Unit = {
+      num += i
+    }
+
+    def get = num
+  }
+  implicit val MyHandlerProvider = new AttachmentProvider[MyHandler] {
+    def provide(ctx: scalene.RequestHandlerContext) = new MyHandler
+  }
   
 
   val routes = Routes(
@@ -54,7 +67,14 @@ object Main extends App {
     GET / "sum" / ![Int] / ![Int] to {case (a,b) => (a + b).ok},
 
     GET / "quotient" / ![Int] / 
-      ![Int].filter(_ != 0, "dividend can't be zero") to {case (a,b) => (a / b).ok}
+      ![Int].filter(_ != 0, "dividend can't be zero") to {case (a,b) => (a / b).ok},
+
+    GET / "shutdown" + Context to {ctx => 
+      ctx.closeConnection
+      "bye".ok
+    },
+
+    GET / "increment" + Attachment[MyHandler] to {h => h.incrementBy(1); h.get.ok}
   )
   
   val settings = Settings.basic(serverName = "examples", port = 8080)

--- a/scalene-routing/src/main/scala/Attachment.scala
+++ b/scalene-routing/src/main/scala/Attachment.scala
@@ -1,0 +1,31 @@
+package scalene.routing
+
+import scalene._
+
+class AttachmentManager(rctx: RequestHandlerContext) {
+  private lazy val attachments = new java.util.HashMap[Int, Any]()
+
+  def set[T](provider: AttachmentProvider[T], attachment: T): Unit = {
+    attachments.put(provider.hashCode, attachment)
+  }
+
+  def get[T](provider: AttachmentProvider[T]): Option[T] = {
+    Option(attachments.get(provider)).map{_.asInstanceOf[T]}
+  }
+
+  def getOrCreate[T](provider: AttachmentProvider[T]): T = {
+    if (attachments.containsKey(provider.hashCode)) {
+      attachments.get(provider.hashCode).asInstanceOf[T]
+    } else {
+      val attachment = provider.provide(rctx)
+      attachments.put(provider.hashCode, attachment)
+      attachment
+    }
+  }
+
+}
+
+
+trait AttachmentProvider[T] {
+  def provide(ctx: RequestHandlerContext): T
+}

--- a/scalene-routing/src/main/scala/RequestContext.scala
+++ b/scalene-routing/src/main/scala/RequestContext.scala
@@ -23,17 +23,20 @@ class LazyPathIterator(getUrl: () => String, startIndex: Int = 1) extends Iterat
 }
 
 
-class RequestContext(val request: HttpRequest, val pathIterator: LazyPathIterator) extends Clonable[RequestContext] with Iterator[String]{
+class RequestContext(val request: HttpRequest, val routingContext: RoutingContext, val pathIterator: LazyPathIterator) extends Clonable[RequestContext] with Iterator[String]{
 
-  def this(request: HttpRequest) = {
-    this(request, new LazyPathIterator(() => request.url))
+  def this(request: HttpRequest, routingContext: RoutingContext) = {
+    this(request, routingContext, new LazyPathIterator(() => request.url))
   }
 
   //used when branching
-  def cclone = new RequestContext(request, pathIterator.cclone)
+  def cclone = new RequestContext(request, routingContext, pathIterator.cclone)
 
   def hasNext = pathIterator.hasNext
 
   def next = pathIterator.next
 
+
 }
+
+

--- a/scalene-routing/src/main/scala/Routing.scala
+++ b/scalene-routing/src/main/scala/Routing.scala
@@ -5,15 +5,23 @@ import scalene._
 import scalene.http._
 import scalene.corerouting._
 
+case class RoutingContext(attachments: AttachmentManager, requestHandlerContext: RequestHandlerContext)
+
 object Routing {
 
   def startDetached(settings: HttpServerSettings, routes: HttpRoute)(implicit pool: Pool): Server = {
     //val built = routes.toRoute
     HttpServer.start(settings, implicit context => new RequestHandler[HttpRequest, HttpResponse] {
-    
-      def onInitialize(context: RequestHandlerContext){}
 
-      def handleRequest(request: HttpRequest): Async[HttpResponse] = routes(new RequestContext(request)) match {
+      private var rctx: Option[RoutingContext] = None
+
+
+    
+      def onInitialize(context: RequestHandlerContext){
+        rctx = Some(RoutingContext(new AttachmentManager(context), context))
+      }
+
+      def handleRequest(request: HttpRequest): Async[HttpResponse] = routes(new RequestContext(request, rctx.get)) match {
         case Right(f) => f.resolve(context)
         case Left(reason) => Async.successful(HttpResponse(reason.reason.code, http.Body.plain(reason.message)))
       }

--- a/scalene-routing/src/main/scala/corerouting/RouteBuilderOps.scala
+++ b/scalene-routing/src/main/scala/corerouting/RouteBuilderOps.scala
@@ -41,13 +41,34 @@ trait RouteBuilderOpsContainer[I <: Clonable[I], FinalOut] { self: RoutingSuite[
 
     /**
      * Combine a buider with a thing that can become a cell component
-     */
+     * this doesn't work, appears to be a scala bug :(
     implicit def builderCom[A , B , CB, FOut](
       implicit fuse: Fuse.Aux[A,B, FOut],
       as: AsCellComponent[I, B, CB]
     ) = new RouteBuilderCombiner[RouteBuilder[A], CB] {
       type Out = RouteBuilder[FOut]
       def apply(a: RouteBuilder[A], b: CB): RouteBuilder[FOut] = RouteBuilder.cons(a, as(b))
+    }
+     */
+    /**
+     * Combine a buider with a parser
+     */
+    implicit def builderParser[A , B , FOut](
+      implicit fuse: Fuse.Aux[A,B, FOut],
+    ) = new RouteBuilderCombiner[RouteBuilder[A], Parser[I,B]] {
+      type Out = RouteBuilder[FOut]
+      def apply(a: RouteBuilder[A], b: Parser[I,B]): RouteBuilder[FOut] = RouteBuilder.cons(a, CellParser(b))
+    }
+
+
+    /**
+     * Combine a buider with a filter
+     */
+    implicit def builderFilter[A , B , FOut](
+      implicit fuse: Fuse.Aux[A,B, FOut],
+    ) = new RouteBuilderCombiner[RouteBuilder[A], Filter[I,B]] {
+      type Out = RouteBuilder[FOut]
+      def apply(a: RouteBuilder[A], b: Filter[I,B]): RouteBuilder[FOut] = RouteBuilder.cons(a, CellFilter(b))
     }
 
     implicit def fuseRoutes[A,B](implicit fuse: Fuse[A,B]) = new RouteBuilderCombiner[RouteBuilder[A], RouteBuilder[B]] {

--- a/scalene-routing/src/main/scala/package.scala
+++ b/scalene-routing/src/main/scala/package.scala
@@ -43,8 +43,16 @@ with PathParsing with ResponseBuilding {
     .recover(_ => None)
 
   //def seq[T](extraction: Extraction[String, T]
+  //
+
+  def Attachment[T](implicit provider: AttachmentProvider[T]): Parser[RequestContext, T] = new Parser[RequestContext, T] {
+    def parse(r: RequestContext) = Right(r.routingContext.attachments.getOrCreate(provider))
+  }
 
 
+  val Context: Parser[RequestContext, RequestHandlerContext] = new Parser[RequestContext, RequestHandlerContext] {
+    def parse(r: RequestContext) = Right(r.routingContext.requestHandlerContext)
+  }
 
   /**
    * wildcard Accept-all path parser, should be used at the end of a path.

--- a/scalene-routing/src/test/scala/SyntaxTests.scala
+++ b/scalene-routing/src/test/scala/SyntaxTests.scala
@@ -57,6 +57,11 @@ class CListTest extends WordSpec with MustMatchers {
       val more = route + ?("foo", ![Int])
     }
 
+    "combine extracted path with other extractor" in {
+      val route = GET / "foo" / ![Int]
+      val more = route + ?("foo", ![Int])
+    }
+
     "combine with wildcard" in {
       val route = GET / "foo" / *
 

--- a/scalene/src/main/scala/scalene/EventLoop.scala
+++ b/scalene/src/main/scala/scalene/EventLoop.scala
@@ -126,7 +126,9 @@ class EventLoop(
   }
 
   private def closeIdleConnections(): Unit = {
+    timeKeeper.refresh()
     val toClose = activeConnections.filter{case (_, c) => 
+      println(s"${c.lastActivity} : ${timeKeeper()} ${c.handler.idleTimeout.toMillis}")
       c.handler.idleTimeout.isFinite && c.lastActivity < (timeKeeper() - c.handler.idleTimeout.toMillis)
     }
     toClose.foreach{case (_, c) => 

--- a/scalene/src/main/scala/scalene/EventLoop.scala
+++ b/scalene/src/main/scala/scalene/EventLoop.scala
@@ -128,7 +128,6 @@ class EventLoop(
   private def closeIdleConnections(): Unit = {
     timeKeeper.refresh()
     val toClose = activeConnections.filter{case (_, c) => 
-      println(s"${c.lastActivity} : ${timeKeeper()} ${c.handler.idleTimeout.toMillis}")
       c.handler.idleTimeout.isFinite && c.lastActivity < (timeKeeper() - c.handler.idleTimeout.toMillis)
     }
     toClose.foreach{case (_, c) => 

--- a/scalene/src/main/scala/scalene/RequestHandler.scala
+++ b/scalene/src/main/scala/scalene/RequestHandler.scala
@@ -2,7 +2,12 @@ package scalene
 
 import util._
 
-case class RequestHandlerContext(time: TimeKeeper)
+trait RequestHandlerContext {
+  def time: TimeKeeper
+
+  def closeConnection(): Unit
+
+}
 
 trait RequestHandler[I,O] {
 

--- a/scalene/src/main/scala/scalene/ServiceServer.scala
+++ b/scalene/src/main/scala/scalene/ServiceServer.scala
@@ -30,7 +30,9 @@ class ServiceServer[I,O](
   }
 
   def onInitialize(env: AsyncContext) {
+    //note - request handler is initialized on onConnected
   }
+
 
   var _handle: Option[ConnectionHandle] = None
 
@@ -58,7 +60,13 @@ class ServiceServer[I,O](
 
   def onConnected(handle: ConnectionHandle) {
     _handle = Some(handle)
-    requestHandler.onInitialize(RequestHandlerContext(handle.time))
+    val rctx = new RequestHandlerContext {
+      def time = handle.time
+      def closeConnection(): Unit = {
+        handle.disconnect()
+      }
+    }
+    requestHandler.onInitialize(rctx)
 
   }
 


### PR DESCRIPTION
## New Features

### Connection Attachments

You can now attach arbitrary objects to connections and access them in routes.  This can allow you to maintain per-connection persistent data.

```scala
//define some mutable object
class Thing {
  var num: Int = 0
}
//create an AttachmentProvider which is basically just a factory
implicit object ThingProvider extends AttachmentProvider[Thing] {
  def provide(context: RequestHandlerContext) = new Thing
}

//now access it in a route
val setRoute = POST / "set" / ![Int] + Attachment[Thing] to {case (num, thing) =>
  thing.num = num
  "set".ok
}

val getRoute = GET / "get" + Attachment[Thing]  to {thing => thing.num.ok}
```
Attachments are lazily created once per connection.

### ConnectionContext

You can also now get access to the connection context with the `Context` parser.  Also since connections are single-threaded, any attachment is also guaranteed to run single-threaded.

```scala

val closeConnectionRoute = GET / "close" + Context to {ctx =>
   ctx.closeConnection
  "bye".ok
}
```

## Bug Fixes

* Fixed an issue with idle connection timeouts not triggering properly
* Fixed a compile-time issue occurring sometimes when combining a route builder with a parser or filter.  Seems to be a Scala bug so a workaround was implemented.
